### PR TITLE
Create save_sp_settings.sql

### DIFF
--- a/restore_sp_settings.sql
+++ b/restore_sp_settings.sql
@@ -1,0 +1,11 @@
+set termout off
+
+-- Get session ID
+COLUMN session_id NEW_VALUE sid NOPRINT
+SELECT SYS_CONTEXT('USERENV', 'SESSIONID') AS session_id FROM DUAL;
+
+-- Restore settings
+@sqlplus_settings_&sid..sql
+
+-- Delete the settings file
+HOST perl -e "unlink 'sqlplus_settings_&sid..sql' if -e 'sqlplus_settings_&sid..sql';"

--- a/save_sp_settings.sql
+++ b/save_sp_settings.sql
@@ -1,0 +1,5 @@
+-- Get session ID
+COLUMN session_id NEW_VALUE sid NOPRINT
+SELECT SYS_CONTEXT('USERENV', 'SESSIONID') AS session_id FROM DUAL;
+-- Store settings in a temporary file
+STORE SET sqlplus_settings_&sid..sql REPLACE


### PR DESCRIPTION
1st commit.  Script to save sqlplus settings to be run at the beginning or prior to another script to allow settings changes to be reverted afterwards